### PR TITLE
Icon patch on logos

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,14 @@
       transform: translate(-50%, -50%);
       filter: drop-shadow(0px 3px 2px rgb(0 0 0 / 0.3))
     }
+    .url-input {
+      width: 80%;
+    }
+    .url-container {
+      text-align: center;
+      width: 100%;
+      height: 20px;
+    }
     .fading {
       animation:fade 1500ms infinite;
     }
@@ -101,35 +109,37 @@
   </style>
 </head>
 <body>
-
-  <main>
-    <button id="default">
-      <img class='image-chrome' src='./images/chrome-logo.svg' />
-      <img class='image-cookie' src='./images/cookie.svg' />
-      <span class='title'>Chrome Default</span>
-    </button>
+    <main>
+      <div class="url-container">
+        <span id="input-label">URL: </span>
+        <input type="text" class="url-input"/>
+      </div>
+      <button id="default">
+        <img class='image-chrome' src='./images/chrome-logo.svg' />
+        <img class='image-cookie' src='./images/cookie.svg' />
+        <span class='title'>Chrome Default</span>
+      </button>
+      
+      <button id="3pcd">
+        <img class='image-chrome' src='./images/chrome-logo.svg' />
+        <img class='image-cookie' src='./images/cookie-off.svg' />
+        <span class='title'>Chrome w/ Disabled Cookies</span>
+      </button>
     
-    <button id="3pcd">
-      <img class='image-chrome' src='./images/chrome-logo.svg' />
-      <img class='image-cookie' src='./images/cookie-off.svg' />
-      <span class='title'>Chrome w/ Disabled Cookies</span>
-    </button>
-  
-    <button id="default-ps">
-      <img class='image-chrome' src='./images/chrome-logo.svg' />
-      <img class='image-psat' src='./images/psat-logo.svg' />
-      <img class='image-cookie' src='./images/cookie.svg' />
-      <span class='title'>Chrome w/ PSAT</span>
-    </button>
-    
-    <button id="3pcd-ps">
-      <img class='image-chrome' src='./images/chrome-logo.svg' />
-      <img class='image-psat' src='./images/psat-logo.svg' />
-      <img class='image-cookie' src='./images/cookie-off.svg' />
-      <span class='title'>Chrome w/ PSAT & Disabled Cookies</span>
-    </button>
-  </main>
-  
+      <button id="default-ps">
+        <img class='image-chrome' src='./images/chrome-logo.svg' />
+        <img class='image-psat' src='./images/psat-logo.svg' />
+        <img class='image-cookie' src='./images/cookie.svg' />
+        <span class='title'>Chrome w/ PSAT</span>
+      </button>
+      
+      <button id="3pcd-ps">
+        <img class='image-chrome' src='./images/chrome-logo.svg' />
+        <img class='image-psat' src='./images/psat-logo.svg' />
+        <img class='image-cookie' src='./images/cookie-off.svg' />
+        <span class='title'>Chrome w/ PSAT & Disabled Cookies</span>
+      </button>
+    </main>
   <script src="./renderer.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -84,25 +84,17 @@
       transform: translate(-50%, -50%);
       filter: drop-shadow(0px 3px 2px rgb(0 0 0 / 0.3))
     }
-    .url-input {
-      width: 80%;
-    }
-    .url-container {
-      text-align: center;
-      width: 100%;
-      height: 20px;
-    }
     .fading {
       animation:fade 1500ms infinite;
     }
     @keyframes fade { 
       0%{opacity:0.2} 50%{opacity:1} 100%{opacity:0.2}
     }
-    [id*='3pcd'] {
+    [id*='default'] {
       --color: #4caf50;
       --color-opacity: #4caf5066;
     }
-    [id*='default'] {
+    [id*='3pcd'] {
       --color: #f44336;
       --color-opacity: #f4433666;
     }
@@ -110,33 +102,23 @@
 </head>
 <body>
     <main>
-      <div class="url-container">
-        <span id="input-label">URL: </span>
-        <input type="text" class="url-input"/>
-      </div>
       <button id="default">
         <img class='image-chrome' src='./images/chrome-logo.svg' />
-        <img class='image-cookie' src='./images/cookie.svg' />
         <span class='title'>Chrome Default</span>
       </button>
       
       <button id="3pcd">
         <img class='image-chrome' src='./images/chrome-logo.svg' />
-        <img class='image-cookie' src='./images/cookie-off.svg' />
         <span class='title'>Chrome w/ Disabled Cookies</span>
       </button>
     
       <button id="default-ps">
         <img class='image-chrome' src='./images/chrome-logo.svg' />
-        <img class='image-psat' src='./images/psat-logo.svg' />
-        <img class='image-cookie' src='./images/cookie.svg' />
         <span class='title'>Chrome w/ PSAT</span>
       </button>
       
       <button id="3pcd-ps">
         <img class='image-chrome' src='./images/chrome-logo.svg' />
-        <img class='image-psat' src='./images/psat-logo.svg' />
-        <img class='image-cookie' src='./images/cookie-off.svg' />
         <span class='title'>Chrome w/ PSAT & Disabled Cookies</span>
       </button>
     </main>


### PR DESCRIPTION
Chrome logo has requirements that it cannot be obstructed by any other images. This patch removes the cookies and PSAT icons overlayed on the logo